### PR TITLE
Fixed exception in ModToolInfo

### DIFF
--- a/gr-utils/modtool/core/info.py
+++ b/gr-utils/modtool/core/info.py
@@ -50,7 +50,7 @@ class ModToolInfo(ModTool):
             if os.path.isdir(os.path.join('include', 'gnuradio', mod_info['modname'])):
                 self.info.version = '310'
         mod_info['version'] = self.info.version
-        if 'is_component' in list(self.info.keys()) and self.info.is_component:
+        if self.info.is_component is True:
             mod_info['is_component'] = True
         mod_info['incdirs'] = []
         mod_incl_dir = os.path.join(mod_info['base_dir'], 'include')


### PR DESCRIPTION
Because `self.info` is now a `ToolConfig` object, it doesn't have `.keys()` anymore. For `gr_modtool info` to work at all without throwing an exception, this call should be removed.